### PR TITLE
fix: GET endpoint should return 404 if no compute node found

### DIFF
--- a/lambda/service/store_dynamodb/store_dynamodb.go
+++ b/lambda/service/store_dynamodb/store_dynamodb.go
@@ -31,7 +31,7 @@ func (r *NodeDatabaseStore) GetById(ctx context.Context, uuid string) (Node, err
 	if err != nil {
 		return Node{}, fmt.Errorf("error getting node: %w", err)
 	}
-	if response == nil {
+	if response.Item == nil {
 		return Node{}, nil
 	}
 


### PR DESCRIPTION
- returns 404 if no compute node found