### PR TITLE
fix: updates identifier

### DIFF
--- a/fargate/compute-node-provisioner/main.go
+++ b/fargate/compute-node-provisioner/main.go
@@ -41,7 +41,7 @@ func main() {
 		log.Fatalf("LoadDefaultConfig: %v\n", err)
 	}
 
-	nodeIdentifier := fmt.Sprint(utils.GenerateHash(organizationId))
+	nodeIdentifier := fmt.Sprint(utils.GenerateHash(fmt.Sprintf("%s-%v", organizationId, accountUuid)))
 	err = os.Setenv("NODE_IDENTIFIER", nodeIdentifier)
 	if err != nil {
 		log.Fatal("error setting node identifier", err.Error())


### PR DESCRIPTION
- updates unique identifier to be a hash of the orgId and the accountUuid
- This is inline with the restriction of one node type (dev or prod) per workspace, per account i.e you can have 1 DEV node and one PROD node per workspace (per account)